### PR TITLE
Remove need for initial load screen

### DIFF
--- a/src/lib/book/BookCard.svelte
+++ b/src/lib/book/BookCard.svelte
@@ -22,13 +22,7 @@
 	class="bg-[#e4e7ee] p-2 rounded-sm grid grid-cols-[1fr_75%] md:grid-cols-[150px_1fr] gap-x-2 shadow-sm"
 >
 	<a class="h-min" href="/book/{book.id}" sveltekit:prefetch>
-		<img
-			loading="lazy"
-			class="shadow-sm rounded-sm"
-			src={coverUrl}
-			width="150px"
-			alt="Cover image for {book.title}"
-		/>
+		<img loading="lazy" class="shadow-sm rounded-sm" src={coverUrl} alt="Cover for {book.title}" />
 	</a>
 	<div class="flex flex-col gap-2">
 		<a href="/book/{book.id}" sveltekit:prefetch>

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -31,7 +31,7 @@
 </script>
 
 <div
-	class="duration-150 ease-in-out 
+	class="duration-150 ease-in-out
 	{$windowWidth < 1024 ? 'fixed z-50 flex' : ''}
 	{$windowWidth < 1024 && $sidebarOpen ? 'w-full' : ''}
 	{$sidebarOpen ? '' : '-ml-64'}"

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -5,7 +5,6 @@
 	import { sidebarOpen } from '$lib/stores/sidebarStore';
 	import { windowWidth } from '$lib/stores/windowWidthStore';
 	import { onMount } from 'svelte';
-	import { reader } from '$lib/stores/readerStore';
 	import { session } from '$app/stores';
 	import Icon from '$lib/components/Icon.svelte';
 
@@ -19,23 +18,28 @@
 		}
 	};
 
-	$: if ($windowWidth < 1024) {
-		sidebarOpen.set(false);
-	}
+	let initialLoad = true;
 
 	onMount(() => {
-		if ($windowWidth >= 1024) {
-			sidebarOpen.set(true);
-		}
+		hideSidebar();
+		initialLoad = false;
 	});
 </script>
+
+<svelte:window
+	bind:innerWidth={$windowWidth}
+	on:resize={() => {
+		hideSidebar();
+	}}
+/>
 
 <div
 	class="duration-150 ease-in-out
 	fixed z-50 flex lg:static lg:z-auto lg:block
+	{initialLoad ? '-ml-64 lg:ml-0' : ''}
 	{$sidebarOpen ? '' : '-ml-64'}"
 >
-	{#if $sidebarOpen && $windowWidth < 1024}
+	{#if $sidebarOpen && $windowWidth < 1024 && !initialLoad}
 		<div
 			transition:fade={{ duration: 150 }}
 			on:click={toggleSidebar}

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -14,29 +14,29 @@
 	};
 
 	const hideSidebar = () => {
-		if ($windowWidth <= 1000) {
+		if ($windowWidth < 1024) {
 			sidebarOpen.set(false);
 		}
 	};
 
-	$: if ($windowWidth <= 1000) {
+	$: if ($windowWidth < 1024) {
 		sidebarOpen.set(false);
 	}
 
 	onMount(() => {
-		if ($windowWidth > 1000) {
+		if ($windowWidth >= 1024) {
 			sidebarOpen.set(true);
 		}
 	});
 </script>
 
 <div
-	class="duration-150 ease-in-out     
-	{$windowWidth <= 1000 ? 'fixed z-50 flex' : ''}
-	{$windowWidth <= 1000 && $sidebarOpen ? 'w-full' : ''}
+	class="duration-150 ease-in-out 
+	{$windowWidth < 1024 ? 'fixed z-50 flex' : ''}
+	{$windowWidth < 1024 && $sidebarOpen ? 'w-full' : ''}
 	{$sidebarOpen ? '' : '-ml-64'}"
 >
-	{#if $sidebarOpen && $windowWidth <= 1000}
+	{#if $sidebarOpen && $windowWidth < 1024}
 		<div
 			transition:fade={{ duration: 150 }}
 			on:click={toggleSidebar}

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -32,8 +32,7 @@
 
 <div
 	class="duration-150 ease-in-out
-	{$windowWidth < 1024 ? 'fixed z-50 flex' : ''}
-	{$windowWidth < 1024 && $sidebarOpen ? 'w-full' : ''}
+	fixed z-50 flex lg:static lg:z-auto lg:block
 	{$sidebarOpen ? '' : '-ml-64'}"
 >
 	{#if $sidebarOpen && $windowWidth < 1024}

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -11,6 +11,7 @@
 
 	import Modal from 'svelte-simple-modal';
 	import { modal } from '$lib/stores/modalStore';
+	import Icon from '$lib/components/Icon.svelte';
 
 	let initialLoad = true;
 
@@ -27,7 +28,9 @@
 
 <SupaAuthHelper {supabaseClient} {session} autoRefreshToken={true}>
 	{#if initialLoad}
-		<div class="flex bg-[#fafafa]" />
+		<div class="flex h-screen w-screen justify-center items-center bg-[#fafafa]">
+			<Icon height="48" width="48" name="loading" class="animate-spin" />
+		</div>
 	{:else}
 		<Modal show={$modal} />
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -16,7 +16,7 @@
 	let initialLoad = true;
 
 	onMount(async () => {
-		if ($windowWidth <= 1000) {
+		if ($windowWidth < 1024) {
 			sidebarOpen.set(false);
 		}
 		initialLoad = false;
@@ -39,7 +39,7 @@
 
 			<!-- Hack to make screen full on smaller widths -->
 			<!-- Normally done on sidebar, but sidebar is removed from flow on small screens -->
-			{#if $windowWidth <= 1000}
+			{#if $windowWidth < 1024}
 				<div class="h-screen" />
 			{/if}
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -2,54 +2,32 @@
 	import '../app.css';
 	import Header from '$lib/header/Header.svelte';
 	import Sidebar from '$lib/sidebar/Sidebar.svelte';
-	import { windowWidth } from '$lib/stores/windowWidthStore';
-	import { onMount } from 'svelte';
-	import { sidebarOpen } from '$lib/stores/sidebarStore';
 	import { session } from '$app/stores';
 	import { supabaseClient } from '$lib/db';
 	import { SupaAuthHelper } from '@supabase/auth-helpers-svelte';
 
 	import Modal from 'svelte-simple-modal';
 	import { modal } from '$lib/stores/modalStore';
-	import Icon from '$lib/components/Icon.svelte';
-
-	let initialLoad = true;
-
-	onMount(async () => {
-		if ($windowWidth < 1024) {
-			sidebarOpen.set(false);
-		}
-		initialLoad = false;
-	});
 </script>
 
 <svelte:head><title>Light Novel DB</title></svelte:head>
-<svelte:window bind:innerWidth={$windowWidth} />
 
 <SupaAuthHelper {supabaseClient} {session} autoRefreshToken={true}>
-	{#if initialLoad}
-		<div class="flex h-screen w-screen justify-center items-center bg-[#fafafa]">
-			<Icon height="48" width="48" name="loading" class="animate-spin" />
-		</div>
-	{:else}
-		<Modal show={$modal} />
+	<Modal show={$modal} />
 
-		<div class="flex">
-			<Sidebar />
+	<div class="flex">
+		<Sidebar />
 
-			<!-- Hack to make screen full on smaller widths -->
-			<!-- Normally done on sidebar, but sidebar is removed from flow on small screens -->
-			{#if $windowWidth < 1024}
-				<div class="h-screen" />
-			{/if}
+		<!-- Hack to make screen full on smaller widths -->
+		<!-- Normally done on sidebar, but sidebar is removed from flow on small screens -->
+		<div class="h-screen lg:hidden" />
 
-			<div class="flex flex-col flex-grow bg-[#fafafa]">
-				<Header />
+		<div class="flex flex-col flex-grow bg-[#fafafa]">
+			<Header />
 
-				<div class="flex-grow">
-					<slot />
-				</div>
+			<div class="flex-grow">
+				<slot />
 			</div>
 		</div>
-	{/if}
+	</div>
 </SupaAuthHelper>


### PR DESCRIPTION
Previously, we needed an initial load screen to hide the content while JS is running to show or hide the sidebar depending on the screen width.

However, for users without JS, this will only ever display a white screen. 

This PR fixes this issue by uses media queries and setting default classes on the first load to display the correct content and then adding JS after so users can toggle the sidebar.