### PR TITLE
Fix 401 error when refreshing access token

### DIFF
--- a/src/routes/book/[id].ts
+++ b/src/routes/book/[id].ts
@@ -4,8 +4,8 @@ import type { RequestHandler } from '@sveltejs/kit';
 import type BookInfo from '$lib/models/bookInfo';
 import type Release from '$lib/models/release';
 
-export const GET: RequestHandler = async ({ params, locals, request }) => {
-	const { data, error, status } = await supabaseServerClient(request)
+export const GET: RequestHandler = async ({ params, locals }) => {
+	const { data, error, status } = await supabaseServerClient(locals.accessToken)
 		.from<BookInfo>('book_info')
 		.select('*')
 		.eq('id', params.id);
@@ -19,7 +19,7 @@ export const GET: RequestHandler = async ({ params, locals, request }) => {
 		};
 	}
 
-	const { data: releases, error: relError } = await supabaseServerClient(request)
+	const { data: releases, error: relError } = await supabaseServerClient(locals.accessToken)
 		.from<Release>('book_releases')
 		.select('*')
 		.eq('book_id', params.id);
@@ -29,7 +29,7 @@ export const GET: RequestHandler = async ({ params, locals, request }) => {
 		};
 	}
 
-	const { data: seriesBooks, error: sError } = await supabaseServerClient(request).rpc(
+	const { data: seriesBooks, error: sError } = await supabaseServerClient(locals.accessToken).rpc(
 		'get_books_same_series',
 		{
 			f_book_id: params.id
@@ -47,7 +47,7 @@ export const GET: RequestHandler = async ({ params, locals, request }) => {
 
 	let readingStatus: string | null = null;
 	if (locals.user) {
-		const { data: readData, error } = await supabaseServerClient(request)
+		const { data: readData, error } = await supabaseServerClient(locals.accessToken)
 			.from('reads')
 			.select(
 				`

--- a/src/routes/books/index.ts
+++ b/src/routes/books/index.ts
@@ -2,8 +2,8 @@ import { supabaseServerClient } from '@supabase/auth-helpers-sveltekit';
 import type { RequestHandler } from '@sveltejs/kit';
 import type BookInfo from '$lib/models/bookInfo';
 
-export const GET: RequestHandler = async ({ request }) => {
-	const { data, error, status } = await supabaseServerClient(request)
+export const GET: RequestHandler = async ({ locals }) => {
+	const { data, error, status } = await supabaseServerClient(locals.accessToken)
 		.from<BookInfo>('book_info')
 		.select('*')
 		.order('title_romaji', { ascending: true });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,20 +2,20 @@ import { supabaseServerClient } from '@supabase/auth-helpers-sveltekit';
 import type { RequestHandler } from '@sveltejs/kit';
 import type BookInfo from '$lib/models/bookInfo';
 
-export const GET: RequestHandler = async ({ request }) => {
+export const GET: RequestHandler = async ({ locals }) => {
 	const date = new Date();
 
 	const {
 		data: dataThisMonth,
 		error: errorThisMonth,
 		status: statusThisMonth
-	} = await supabaseServerClient(request)
+	} = await supabaseServerClient(locals.accessToken)
 		.from<BookInfo>('book_info')
 		.select('*')
 		.gte('release_date', `${date.getFullYear()}-${date.getMonth() + 1}-01`)
 		.order('title_romaji', { ascending: true });
 
-	const { data: dataRecent, error: errorRecent } = await supabaseServerClient(request)
+	const { data: dataRecent, error: errorRecent } = await supabaseServerClient(locals.accessToken)
 		.from<BookInfo>('book_info')
 		.select('*')
 		.limit(10)

--- a/src/routes/my-list/index.ts
+++ b/src/routes/my-list/index.ts
@@ -5,9 +5,9 @@ import type Reader from '$lib/models/reader';
 import type Reads from '$lib/models/reads';
 import type ReaderLabels from '$lib/models/readerLabels';
 
-export const GET: RequestHandler = async ({ url, locals, request }) =>
+export const GET: RequestHandler = async ({ url, locals }) =>
 	withApiAuth({ redirectTo: '/', user: locals.user }, async () => {
-		const query = supabaseServerClient(request)
+		const query = supabaseServerClient(locals.accessToken)
 			.from<BookInfo & Reader & Reads & ReaderLabels>('reader_list')
 			.select('*')
 			.eq('auth_id', locals.user.id)


### PR DESCRIPTION
Before, we injected the request into the supabaseClient to set the current user. 
When the access token is expired, we automatically send a request to Supabase to refresh the access token.
However, this only updates the access token in locals.accessToken and cannot update the one in the request.
To fix this, we simply change it to use locals.accessToken instead of request.